### PR TITLE
Add ability to translate error messages from API to prettier ones

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     "camelcase": "off",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "comma-dangle": "off"
   }
 }

--- a/components/lib/translateErrors.js
+++ b/components/lib/translateErrors.js
@@ -1,0 +1,26 @@
+/*
+  'context': [
+    ['regex to match with rawMessage', 'Pretty Message']
+  ]
+*/
+
+const commonErrorsMap = [
+  [/is duplicate$/, 'This URL is already part of this list.'],
+  [/Invalid URL$/, 'The URL is not in a valid format. Here is an example of a valid one: http://ooni.org/']
+]
+
+const errorsMap = {
+  add: [
+    ...commonErrorsMap,
+  ],
+  edit: [
+    ...commonErrorsMap,
+  ]
+}
+
+export const getPrettyErrorMessage = (rawErrorMessage, context) => {
+  if (context in errorsMap) {
+    return errorsMap[context].find(([regex, prettyMessage]) => regex.test(rawErrorMessage))?.[1] ?? rawErrorMessage
+  }
+  return rawErrorMessage
+}

--- a/components/submit/EditForm.js
+++ b/components/submit/EditForm.js
@@ -34,11 +34,11 @@ export const EditForm = ({ oldEntry, error, onSubmit, onCancel, layout = 'column
     const comment = formData.get('comment')
     try {
       await onSubmit(newEntry, comment)
-      console.log('onSubmit succeeded')
+      console.debug('onSubmit succeeded')
       e.target.reset()
     } catch (e) {
       // Submit failed, don't change form state yet
-      console.log(`Submit failed: ${e.message}`)
+      console.debug(`Submit failed: ${e}`)
     } finally {
       setSubmitting(false)
     }
@@ -87,7 +87,7 @@ export const EditForm = ({ oldEntry, error, onSubmit, onCancel, layout = 'column
 
         {!isEdit && <Button type='submit' hollow disabled={submitting}>Add</Button>}
       </Flex>
-      <Box as='small' color='red6'> {error} </Box>
+      <Box color='red6'> {error} </Box>
     </form>
   )
 }

--- a/components/submit/UrlList.js
+++ b/components/submit/UrlList.js
@@ -10,6 +10,7 @@ import ModalWithEsc from './ModalWithEsc'
 import DeleteForm from './DeleteForm'
 import Loading from '../Loading'
 import SubmitButton from './SubmitButton'
+import { getPrettyErrorMessage } from '../lib/translateErrors'
 
 // Does these
 // * Decides what data to pass down to the table
@@ -95,7 +96,8 @@ const UrlList = ({ cc }) => {
 
           resolve()
         }).catch(e => {
-          setAddFormError(`addURL failed: ${e?.response?.data?.error ?? e}`)
+          const prettyErrorMessage = getPrettyErrorMessage(e?.response?.data?.error ?? e, 'add')
+          setAddFormError(prettyErrorMessage)
           reject(e?.response?.data?.error ?? e)
         })
       } else {
@@ -110,7 +112,8 @@ const UrlList = ({ cc }) => {
 
           resolve()
         }).catch(e => {
-          setEditFormError(`Update URL failed: ${e?.response?.data?.error ?? e}`)
+          const prettyErrorMessage = getPrettyErrorMessage(e?.response?.data?.error ?? e, 'add')
+          setEditFormError(prettyErrorMessage)
           reject(e?.response?.data?.error ?? e)
         })
       }
@@ -150,8 +153,11 @@ const UrlList = ({ cc }) => {
               <EditForm layout='row' onSubmit={handleSubmit} oldEntry={{}} error={addFormError} />
             }
           </Box>
+
           <SubmitButton />
+
           <Table data={data} onEdit={onEdit} onDelete={onDelete} skipPageReset={skipPageReset} submissionState={submissionState} />
+
           {editIndex !== null && (
             <ModalWithEsc onCancel={onCancel} show={editIndex !== null} onHideClick={onCancel}>
               <Container sx={{ width: ['90vw', '40vw'] }} px={[2, 5]} py={[2, 3]} color='gray8'>
@@ -159,6 +165,7 @@ const UrlList = ({ cc }) => {
               </Container>
             </ModalWithEsc>
           )}
+
           {deleteIndex !== null && (
             <ModalWithEsc onCancel={onCancelDelete} show={deleteIndex !== null} onHideClick={onCancelDelete}>
               <Container sx={{ width: ['90vw', '40vw'] }} px={[2, 5]} py={[2, 3]} color='gray8'>


### PR DESCRIPTION
Fixes #3﻿

Preview: https://test-lists.test.ooni.org/

This should really be done in a better way. Ideally by agreeing to use a common set of error codes on API and here and map them to localized and copy-edited messages

The alternative, that I prefer less, is to send such copy-edited error messages directly from the API.

@agrabeli Please suggest if you think the messages can be worded better. For now, I have only added two of them:
* 'This URL is already part of this list.'
* 'The URL is not in a valid format. Here is an example of a valid one: http://ooni.org/'

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/700829/136485018-971ce9c5-c567-4cfe-a928-bdddc08e990d.png">
