### PR TITLE
Add hints to comment and notes input

### DIFF
--- a/components/submit/EditForm.js
+++ b/components/submit/EditForm.js
@@ -44,12 +44,12 @@ export const EditForm = ({ oldEntry, error, onSubmit, onCancel, layout = 'column
     }
   }, [oldEntry.date_added, oldEntry.source, onSubmit])
 
-  const width = layout === 'row' ? (1 / 4) : 1
+  const width = layout === 'row' ? (1 / 3) : 1
 
   return (
     <form onSubmit={handleSubmit}>
       <Heading h={4}>{isEdit ? `Editing ${oldEntry.url}` : 'Add new URL'}</Heading>
-      <Flex flexDirection={layout} my={2} mx={2} alignItems='center'>
+      <Flex flexDirection={layout} my={2} mx={2} alignItems='center' flexWrap='wrap'>
 
         <Flex flexDirection='column' my={2} width={width} px={3}>
           <Label htmlFor='url'>URL</Label>
@@ -70,12 +70,12 @@ export const EditForm = ({ oldEntry, error, onSubmit, onCancel, layout = 'column
 
         <Flex flexDirection='column' my={2} width={width} px={3}>
           <Label htmlFor='notes'>Notes</Label>
-          <Input name='notes' type='text' placeholder='' defaultValue={oldEntry.notes} />
+          <Input name='notes' type='text' placeholder='Document any useful context for this URL' defaultValue={oldEntry.notes} />
         </Flex>
 
-        <Flex flexDirection='column' my={2} width={width} px={3}>
+        <Flex flexDirection='column' my={2} width={width} px={3} flexGrow={'auto'}>
           <Label htmlFor='comment'>Comment</Label>
-          <Input name='comment' type='text' required={true} placeholder='Reason' defaultValue={oldEntry.comment} />
+          <Input name='comment' type='text' required={true} placeholder="Please share why you are updating this URL" defaultValue={oldEntry.comment} />
         </Flex>
 
         {isEdit && (


### PR DESCRIPTION
Fixes #7

Preview: https://test-lists.test.ooni.org/
﻿
Changed layout of the Add URL form a bit for the placeholder text to show.
![image](https://user-images.githubusercontent.com/700829/136483945-2e927f5f-abef-40eb-979c-721340b73093.png)

Original one-row layout with placeholder:
![image](https://user-images.githubusercontent.com/700829/136484077-d35ce6c4-15fb-48e1-999f-b9db7744c58a.png)
